### PR TITLE
Ensure proper `label[for]` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 master
 ------
 
+* Change behvaior of `fillForm` to only work on
+  `<label for="text">Text</label><input id="text">`, in addition to
+  `<label>Text <input></label>`
+
 0.0.2
 -----
 

--- a/blueprints/ember-formulaic/index.js
+++ b/blueprints/ember-formulaic/index.js
@@ -8,10 +8,12 @@ module.exports = {
   },
 
   afterInstall: function() {
-    this.insertIntoFile('tests/.jshintrc', '    "clickOn",' , {
-      after: '"predef": [\n'
-    });
-    this.insertIntoFile('tests/.jshintrc', '    "fillForm",' , {
+    var predefs = [
+      '    "clickOn",',
+      '    "fillForm",',
+    ].join('\n');
+
+    this.insertIntoFile('tests/.jshintrc',  predefs, {
       after: '"predef": [\n'
     });
 

--- a/test-support/helpers/fill-in-label.js
+++ b/test-support/helpers/fill-in-label.js
@@ -1,25 +1,45 @@
 import Ember from 'ember';
 
+const { run } = Ember;
+
 export default function(app, i18n, value) {
   const {
     clickOn,
+    find,
+    findWithAssert,
     fillIn,
-    t
+    t,
+    wait
   } = app.testHelpers;
   const text = t(i18n);
   const label = `label:contains("${text}")`;
-  const selector = [
-    `${label} input:not([type="checkbox"])`,
-    `${label} + input:not([type="checkbox"])`,
-    `${label} textarea`,
-    `${label} + textarea`,
-    `${label} select`,
-    `${label} + select`,
-  ].join(',');
 
-  return fillIn(selector, value)
-    .then(
-      Ember.K,
-      () => clickOn(i18n)
-    );
+  run(() => {
+    const $label = find(label);
+    const id = $label.prop('for');
+
+    if (id) {
+      const $element = findWithAssert(`#${id}`);
+
+      if ($element.prop('type') === 'checkbox') {
+        $element.prop('checked', value);
+      } else {
+        $element.val(value);
+      }
+    } else {
+      const nested = [
+        `${label} input:not([type="checkbox"])`,
+        `${label} textarea`,
+        `${label} select`,
+      ].join(',');
+
+      fillIn(nested, value)
+        .then(
+          () => wait(),
+          () => clickOn(i18n)
+        );
+    }
+
+    return wait();
+  });
 };

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -1,12 +1,12 @@
 export default {
   'form': {
-    'button': 'Sibling Button',
-    'checkbox': 'Sibling Checkbox',
-    'multi-select': 'Sibling Multi-Select',
-    'select': 'Sibling Select',
-    'submit': 'Sibling Submit',
-    'text': 'Sibling Text',
-    'textarea': 'Sibling Textarea',
+    'button': 'For ID Button',
+    'checkbox': 'For ID Checkbox',
+    'multi-select': 'For ID Multi-Select',
+    'select': 'For ID Select',
+    'submit': 'For ID Submit',
+    'text': 'For ID Text',
+    'textarea': 'For ID Textarea',
   },
   'nested': {
     'button': 'Nested Button',


### PR DESCRIPTION
Filling in a `label`'s `{input,textarea,select}` based on proximity or
sibling hierarchy, while possible, is **not** semantically correct, and
is different than browser / a11y behavior.

This commit changes the behavior of `fillForm` (implemented in terms of
`fillInLabel`) to behave properly.
