### PR TITLE
`clickOn` supports `a` and `input[type="radio"]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Add `clickOn` support for `<a>` tags and `<input type="radio">`
+
 0.0.4
 -----
 

--- a/addon/click-on.js
+++ b/addon/click-on.js
@@ -8,6 +8,7 @@ Ember.Test.registerAsyncHelper('clickOn', function(app, i18n) {
 
   const text = t(i18n);
   const selector = [
+    `a:contains("${text}")`,
     `label:contains("${text}")`,
     `button:contains("${text}")`,
     `input[type="submit"][value="${text}"]`,

--- a/addon/fill-in-label.js
+++ b/addon/fill-in-label.js
@@ -22,7 +22,7 @@ export default function(app, i18n, value) {
     if (id) {
       const $element = findWithAssert(`#${id}`);
 
-      if ($element.prop('type') === 'checkbox') {
+      if ($element.prop('type').match(/checkbox|radio/i)) {
         click($element);
       } else {
         fillIn($element, value);

--- a/tests/acceptance/user-click-on-test.js
+++ b/tests/acceptance/user-click-on-test.js
@@ -16,15 +16,26 @@ test('button', assert => {
 
   andThen(function() {
     assert.equal(find('#submitted').length, 0, 'clicking button submits form');
-    assert.equal(find('#nested-submitted').length, 0, 'clicking button submits nested form');
   });
 
   clickOn('form.button');
-  clickOn('nested.button');
 
   andThen(function() {
     assert.ok(findWithAssert('#submitted'), 'clicking button submits form');
-    assert.ok(findWithAssert('#nested-submitted'), 'clicking button submits nested form');
+  });
+});
+
+test('anchor', assert => {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('#submitted').length, 0, 'clicking anchor submits form');
+  });
+
+  clickOn('form.anchor');
+
+  andThen(function() {
+    assert.ok(findWithAssert('#submitted'), 'clicking anchor submits form');
   });
 });
 
@@ -42,6 +53,38 @@ test('submit', assert => {
   andThen(function() {
     assert.ok(findWithAssert('#submitted'), 'clicking button submits form');
     assert.ok(findWithAssert('#nested-submitted'), 'clicking button submits nested form');
+  });
+});
+
+test('radio', assert => {
+  visit('/');
+
+  clickOn('form.radio.yes');
+  clickOn('nested.radio.yes');
+
+  andThen(function() {
+    assert.ok(
+      findWithAssert('#yes').prop('checked'),
+      'clicking yes checks it'
+    );
+    assert.ok(
+      findWithAssert('#nested-yes').prop('checked'),
+      'clicking nested yes checks it'
+    );
+  });
+
+  clickOn('form.radio.no');
+  clickOn('nested.radio.no');
+
+  andThen(function() {
+    assert.ok(
+      findWithAssert('#no').prop('checked'),
+      'clicking no checks it'
+    );
+    assert.ok(
+      findWithAssert('#nested-no').prop('checked'),
+      'clicking nested no checks it'
+    );
   });
 });
 

--- a/tests/acceptance/user-fills-form-with-fill-in-label-test.js
+++ b/tests/acceptance/user-fills-form-with-fill-in-label-test.js
@@ -67,6 +67,30 @@ test('multiple select', assert => {
   });
 });
 
+test('radio', assert => {
+  visit('/');
+
+  fillForm({
+    'form.radio.yes': true,
+    'nested.radio.yes': true,
+  });
+
+  andThen(function() {
+    assert.ok(findWithAssert('#yes').prop('checked'), 'checks yes');
+    assert.ok(findWithAssert('#nested-yes').prop('checked'), 'checks nested yes');
+  });
+
+  fillForm({
+    'form.radio.no': true,
+    'nested.radio.no': true,
+  });
+
+  andThen(function() {
+    assert.ok(findWithAssert('#no').prop('checked'), 'checks no');
+    assert.ok(findWithAssert('#nested-no').prop('checked'), 'checks nested no');
+  });
+});
+
 test('checkbox', assert => {
   visit('/');
 

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -1,8 +1,13 @@
 export default {
   'form': {
+    'anchor': 'For ID Anchor',
     'button': 'For ID Button',
     'checkbox': 'For ID Checkbox',
     'multi-select': 'For ID Multi-Select',
+    'radio': {
+      'yes': 'For ID Yes',
+      'no': 'For ID No',
+    },
     'select': 'For ID Select',
     'submit': 'For ID Submit',
     'text': 'For ID Text',
@@ -16,5 +21,9 @@ export default {
     'submit': 'Nested Submit',
     'text': 'Nested Text',
     'textarea': 'Nested Textarea',
+    'radio': {
+      'yes': 'Nested Yes',
+      'no': 'Nested No',
+    },
   },
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -34,7 +34,17 @@
     <input id="checkbox" type="checkbox">
   </div>
 
+  <div class="input">
+    <label for="yes">{{t "form.radio.yes"}}</label>
+    <input id="yes" name="radio" type="radio" value="yes">
+
+    <label for="no">{{t "form.radio.no"}}</label>
+    <input id="no" name="radio" type="radio" value="no">
+  </div>
+
   <button>{{t "form.button"}}</button>
+
+  <a href="#" {{action "submit"}}>{{t "form.anchor"}}</a>
 
   <input type="submit" value={{t "form.submit"}}>
 </form>
@@ -79,6 +89,20 @@
 
     <input id="nested-checkbox" type="checkbox">
   </label>
+
+  <div class="input">
+    <label for="nested-yes">
+      {{t "nested.radio.yes"}}
+
+      <input id="nested-yes" name="nested-radio" type="radio" value="yes">
+    </label>
+
+    <label for="nested-no">
+      {{t "nested.radio.no"}}
+
+      <input id="nested-no" name="nested-radio" type="radio" value="no">
+    </label>
+  </div>
 
   <button>{{t "nested.button"}}</button>
 


### PR DESCRIPTION
Add support to `clickOn` test helper for `<a>` tags and `<input
type="radio">`.
