### PR TITLE
Extend `fillForm` to accept I18n namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Accept an I18n namespace to be prepended to `fillForm`'s translation keys
+
 0.0.5
 -----
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ In your acceptance test, use the `fillForm` method:
 test('fill in form', function() {
   visit('/login')
 
+  // with the 'login' namespace
+  fillForm('login', {
+    email: 'ralph@thoughtbot.com',
+    password: 'secret',
+    remember-me: true,
+    role: 'user',
+  });
+
+  // without a namespace
   fillForm({
     'login.email': 'ralph@thoughtbot.com',
     'login.password': 'secret',

--- a/addon/fill-form.js
+++ b/addon/fill-form.js
@@ -1,11 +1,23 @@
 import Ember from 'ember';
 import fillInLabel from './fill-in-label';
 
-Ember.Test.registerAsyncHelper('fillForm', function(app, i18nKeysAndValues) {
-  const promises = Object.keys(i18nKeysAndValues).map(i18nKey => {
-    const value = i18nKeysAndValues[i18nKey];
+Ember.Test.registerAsyncHelper('fillForm', function(app, namespace, hash) {
+  if (!namespace) {
+    throw '`fillForm` expects the first argument to be a String that ' +
+          'will be prepended to all I18n keys, or an Object whose keys ' +
+          ' are I18n keys.';
+  } else if (typeof namespace === 'object') {
+    hash = namespace;
+    namespace = null;
+  }
 
-    return fillInLabel(app, i18nKey, value);
+  const promises = Object.keys(hash).map(i18nKey => {
+    const value = hash[i18nKey];
+    const namespacedKey = Ember.A([namespace, i18nKey])
+      .filter(i => i)
+      .join('.');
+
+    return fillInLabel(app, namespacedKey, value);
   });
 
   return Ember.RSVP.all(promises);

--- a/tests/acceptance/user-fills-form-with-fill-in-label-test.js
+++ b/tests/acceptance/user-fills-form-with-fill-in-label-test.js
@@ -23,6 +23,18 @@ test('text', assert => {
     assert.equal(findWithAssert('#text').val(), 'text');
     assert.equal(findWithAssert('#nested-text').val(), 'text');
   });
+
+  fillForm('form', {
+    text: 'namespaced text',
+  });
+
+  andThen(function() {
+    assert.equal(
+      findWithAssert('#text').val(),
+      'namespaced text',
+      'accepts namespace'
+    );
+  });
 });
 
 test('textarea', assert => {


### PR DESCRIPTION
`fillForm` accepts an I18n namespace.

For example:

``` js
// Before

fillForm({
  'this.is.the.namespace.foo': 'foo',
  'this.is.the.namespace.bar': 'bar',
});

// After

fillForm('this.is.the.namespace', {
  foo: 'foo',
  bar: 'bar',
});
```
